### PR TITLE
Use http endpoints to get pong count instead of volume share

### DIFF
--- a/main-app/app1/main.go
+++ b/main-app/app1/main.go
@@ -12,7 +12,7 @@ import (
 const (
 	httpServePort = "8080"
 	timestampFile = "/common-data/time.txt"
-	pongFile      = "/common-data/pong.txt"
+	pongUrl       = "http://pingpong-svc:2346/pongcount"
 )
 
 // Serves timestamp from a file and adds hash
@@ -29,7 +29,7 @@ func defaultHandler(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		fmt.Println(err)
 	}
-	pongCount, err := readFromFile(pongFile)
+	pongCount, err := getPongCount(pongUrl)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -37,6 +37,20 @@ func defaultHandler(w http.ResponseWriter, _ *http.Request) {
 	if _, err := fmt.Fprintf(w, resp); err != nil {
 		fmt.Println(err)
 	}
+}
+
+func getPongCount(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil
+	}
+
+	return string(data), nil
 }
 
 func rndString() string {

--- a/manifests/pingpong-deployment.yaml
+++ b/manifests/pingpong-deployment.yaml
@@ -12,14 +12,7 @@ spec:
       labels:
         app: pingpong
     spec:
-      volumes:
-        - name: common-data
-          persistentVolumeClaim:
-            claimName: data-share
       containers:
         - name: pingpong
           image: hkotka/ping-pong
           imagePullPolicy: Always
-          volumeMounts:
-            - name: common-data
-              mountPath: /common-data

--- a/manifests/pingpong-ingress.yaml
+++ b/manifests/pingpong-ingress.yaml
@@ -2,8 +2,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: pingpong-ingress
-  annotations:
-    traefik.ingress.kubernetes.io/rule-type: "PathPrefixStrip"
 spec:
   rules:
     - http:


### PR DESCRIPTION
Impemented additional REST endpoint to pingpong app for returning pong count. Removed functions and k8s configuration for using files to share data between pods.
